### PR TITLE
Feature/version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,8 @@ COPY ./dist /opt
 
 WORKDIR /opt
 
-RUN pip3 install -r requirements.txt \
-	&& python setup.py develop \
-	&& ln -s /opt/bin/gdc_filtration_tools /bin/gdc_filtration_tools
+RUN make init-pip \
+  && ln -s /opt/bin/gdc_filtration_tools /bin/gdc_filtration_tools
 
 ENTRYPOINT ["/bin/gdc_filtration_tools"]
 

--- a/bin/gdc_filtration_tools
+++ b/bin/gdc_filtration_tools
@@ -9,6 +9,6 @@
 
 case "$1" in
 	test) python -m pytest tests;;
-	*version) python -m gdc_filtration_tools._version $@;;
+	*version) python -m gdc_filtration_tools --version;;
 	*) python -m gdc_filtration_tools $@;;
 esac

--- a/gdc_filtration_tools/__init__.py
+++ b/gdc_filtration_tools/__init__.py
@@ -1,0 +1,3 @@
+from gdc_filtration_tools._version import __short_version__
+
+__version__ = __short_version__

--- a/gdc_filtration_tools/__main__.py
+++ b/gdc_filtration_tools/__main__.py
@@ -44,6 +44,7 @@ def main(args: List[str] = None) -> None:
     defopt.run(
         funcs,
         argv=args if args is not None else sys.argv[1:],
+        version=True,
         argparse_kwargs={'prog': 'gdc_filtration_tools'},
     )
     logger.info("Finished!")


### PR DESCRIPTION
Another method to avoid the earlier problems with `make` commands improperly generating the version string within the docker.

This method assumes the only "important" version is the bare semantic version. 

The reasoning is that the end user should not care about the information provided by the git info.

These updates also treat the semantic version is `__version__` for the module, and is provided when giving the `--version` CLI argument.